### PR TITLE
Execute binary twice for toc

### DIFF
--- a/src/LaraTeX.php
+++ b/src/LaraTeX.php
@@ -273,6 +273,7 @@ class LaraTeX
 
         $process    = new Process($cmd);
         $process->run();
+        $process->run();
         if (!$process->isSuccessful()) {
             \Event::dispatch(new LaratexPdfFailed($fileName, 'download', $this->metadata));
             $this->parseError($tmpfname, $process);


### PR DESCRIPTION
To have a working table of contents you have to execute the binary twice. Not sure if this should be optional but I didn't see any problem by just adding it right there. 