### PR TITLE
Update LaraTeX.php Response Facade fix

### DIFF
--- a/src/LaraTeX.php
+++ b/src/LaraTeX.php
@@ -10,7 +10,7 @@ use Symfony\Component\Process\Process;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Response;
 use Illuminate\Contracts\Config\Repository as ConfigRepository;
 
 class LaraTeX


### PR DESCRIPTION
`use Illuminate\Http\Response;` replaced with `use Illuminate\Support\Facades\Response;` because Illuminate\Http\Response::download() does not exists.

Laravel 11 throws an error on download() and dryRun() methods indicating that Illuminate\Http\Response::download() does not exists. This commit solves the issue.